### PR TITLE
Implement admin console with DB lists

### DIFF
--- a/src/main/java/com/example/demo/DatabaseInfoMapper.java
+++ b/src/main/java/com/example/demo/DatabaseInfoMapper.java
@@ -1,0 +1,18 @@
+package com.example.demo;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface DatabaseInfoMapper {
+    @Select("SELECT datname FROM pg_database")
+    List<String> selectDatabases();
+
+    @Select("SELECT schema_name FROM information_schema.schemata")
+    List<String> selectSchemas();
+
+    @Select("SELECT usename FROM pg_user")
+    List<String> selectUsers();
+}

--- a/src/main/java/com/example/demo/HomeController.java
+++ b/src/main/java/com/example/demo/HomeController.java
@@ -4,18 +4,36 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.util.List;
+import com.example.demo.DatabaseInfoMapper;
+
+/**
+ * Provides the home page for the simple management console.
+ */
+
 @Controller
 public class HomeController {
     private final VersionMapper versionMapper;
+    private final DatabaseInfoMapper databaseInfoMapper;
 
-    public HomeController(VersionMapper versionMapper) {
+    public HomeController(VersionMapper versionMapper, DatabaseInfoMapper databaseInfoMapper) {
         this.versionMapper = versionMapper;
+        this.databaseInfoMapper = databaseInfoMapper;
     }
 
     @GetMapping("/")
     public String index(Model model) {
         String dbVersion = versionMapper.selectVersion();
         model.addAttribute("dbVersion", dbVersion);
+
+        List<String> databases = databaseInfoMapper.selectDatabases();
+        List<String> schemas = databaseInfoMapper.selectSchemas();
+        List<String> users = databaseInfoMapper.selectUsers();
+
+        model.addAttribute("databases", databases);
+        model.addAttribute("schemas", schemas);
+        model.addAttribute("users", users);
+
         return "index";
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -2,13 +2,35 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Hello</title>
+    <title>Admin Console</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 flex items-center justify-center min-h-screen">
-<div class="bg-white shadow-lg rounded p-8 text-center">
-<h1 class="text-3xl font-bold mb-4">Hello World!</h1>
-<p class="text-gray-700">PostgreSQL version: <span class="font-mono" th:text="${dbVersion}"></span></p>
-</div>
+<body class="bg-gray-100 min-h-screen">
+<header class="bg-gray-800 text-white p-4 flex justify-between items-center">
+    <h1 class="text-xl font-bold">Admin Console</h1>
+    <span class="text-sm" th:text="${dbVersion}"></span>
+</header>
+<main class="p-4">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div>
+            <h2 class="font-semibold mb-2">Databases</h2>
+            <ul class="bg-white shadow rounded p-2" >
+                <li th:each="db : ${databases}" th:text="${db}" class="border-b last:border-0 py-1"></li>
+            </ul>
+        </div>
+        <div>
+            <h2 class="font-semibold mb-2">Schemas</h2>
+            <ul class="bg-white shadow rounded p-2" >
+                <li th:each="schema : ${schemas}" th:text="${schema}" class="border-b last:border-0 py-1"></li>
+            </ul>
+        </div>
+        <div>
+            <h2 class="font-semibold mb-2">Users</h2>
+            <ul class="bg-white shadow rounded p-2" >
+                <li th:each="user : ${users}" th:text="${user}" class="border-b last:border-0 py-1"></li>
+            </ul>
+        </div>
+    </div>
+</main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the hello world page with a simple admin console UI
- show DB version in the header
- list databases, schemas and users via MyBatis mapper

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6857da3e44a8832e8db62cc7c25ea151