### PR TITLE
Change connection storage to cookies and tweak console layout

### DIFF
--- a/src/main/java/com/example/demo/ConnectController.java
+++ b/src/main/java/com/example/demo/ConnectController.java
@@ -1,6 +1,7 @@
 package com.example.demo;
 
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,10 +19,25 @@ public class ConnectController {
     public String connect(@RequestParam String username,
                           @RequestParam String password,
                           @RequestParam String database,
-                          HttpSession session) {
-        session.setAttribute("dbUser", username);
-        session.setAttribute("dbPassword", password);
-        session.setAttribute("dbName", database);
+                          HttpServletResponse response) {
+        int maxAge = 7 * 24 * 60 * 60; // 1 week
+
+        Cookie userCookie = new Cookie("dbUser", username);
+        userCookie.setPath("/");
+        userCookie.setMaxAge(maxAge);
+
+        Cookie passwordCookie = new Cookie("dbPassword", password);
+        passwordCookie.setPath("/");
+        passwordCookie.setMaxAge(maxAge);
+
+        Cookie dbCookie = new Cookie("dbName", database);
+        dbCookie.setPath("/");
+        dbCookie.setMaxAge(maxAge);
+
+        response.addCookie(userCookie);
+        response.addCookie(passwordCookie);
+        response.addCookie(dbCookie);
+
         return "redirect:/console";
     }
 }

--- a/src/main/resources/templates/console.html
+++ b/src/main/resources/templates/console.html
@@ -8,23 +8,29 @@
 <body class="bg-gray-100 min-h-screen flex flex-col">
 <header class="bg-gray-800 text-white p-4 flex justify-between items-center">
     <h1 class="text-xl font-bold" th:text="#{header.title}">Admin Console</h1>
-    <div>
-        <a href="/settings" class="underline mr-4" th:text="#{settings.title}">Settings</a>
-        <span class="text-sm" th:text="${dbVersion}"></span>
-    </div>
+    <a href="/settings" class="underline" th:text="#{settings.title}">Settings</a>
 </header>
-<main class="p-4 flex-grow">
-    <nav class="text-sm text-gray-600 mb-4">
-        <a href="/" th:text="#{console.menu.home}">Home</a> / <span th:text="#{console.menu.console}">Console</span>
-    </nav>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <a href="/databases" class="bg-white shadow rounded p-4 text-center" th:text="#{console.databases}">Databases</a>
-        <a href="/schemas" class="bg-white shadow rounded p-4 text-center" th:text="#{console.schemas}">Schemas</a>
-        <a href="/users" class="bg-white shadow rounded p-4 text-center" th:text="#{console.users}">Users</a>
+<main class="flex flex-grow">
+    <aside class="w-64 bg-gray-100 p-4 space-y-2">
+        <a href="/console" class="block" th:text="#{console.menu.console}">Console</a>
+        <a href="/databases" class="block" th:text="#{console.databases}">Databases</a>
+        <a href="/schemas" class="block" th:text="#{console.schemas}">Schemas</a>
+        <a href="/users" class="block" th:text="#{console.users}">Users</a>
+    </aside>
+    <div class="p-4 flex-grow">
+        <nav class="text-sm text-gray-600 mb-4">
+            <a href="/" th:text="#{console.menu.home}">Home</a> / <span th:text="#{console.menu.console}">Console</span>
+        </nav>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <a href="/databases" class="bg-white shadow rounded p-4 text-center" th:text="#{console.databases}">Databases</a>
+            <a href="/schemas" class="bg-white shadow rounded p-4 text-center" th:text="#{console.schemas}">Schemas</a>
+            <a href="/users" class="bg-white shadow rounded p-4 text-center" th:text="#{console.users}">Users</a>
+        </div>
     </div>
 </main>
-<footer class="bg-gray-200 text-center p-4" th:text="#{footer.copy}">
-    © 2024 My Admin Console
+<footer class="bg-gray-200 text-center p-4">
+    <div th:text="${dbVersion}"></div>
+    <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>
 </body>
 </html>

--- a/src/main/resources/templates/databases.html
+++ b/src/main/resources/templates/databases.html
@@ -8,22 +8,28 @@
 <body class="bg-gray-100 min-h-screen flex flex-col">
 <header class="bg-gray-800 text-white p-4 flex justify-between items-center">
     <h1 class="text-xl font-bold" th:text="#{header.title}">Admin Console</h1>
-    <div>
-        <a href="/settings" class="underline mr-4" th:text="#{settings.title}">Settings</a>
-        <span class="text-sm" th:text="${dbVersion}"></span>
-    </div>
+    <a href="/settings" class="underline" th:text="#{settings.title}">Settings</a>
 </header>
-<main class="p-4 flex-grow">
-    <nav class="text-sm text-gray-600 mb-4">
-        <a href="/" th:text="#{console.menu.home}">Home</a> / <a href="/console" th:text="#{console.menu.console}">Console</a> / <span th:text="#{databases.title}">Databases</span>
-    </nav>
-    <h2 class="font-semibold mb-2" th:text="#{databases.title}">Databases</h2>
-    <ul class="bg-white shadow rounded p-2">
-        <li th:each="db : ${databases}" th:text="${db}" class="border-b last:border-0 py-1"></li>
-    </ul>
+<main class="flex flex-grow">
+    <aside class="w-64 bg-gray-100 p-4 space-y-2">
+        <a href="/console" class="block" th:text="#{console.menu.console}">Console</a>
+        <a href="/databases" class="block" th:text="#{console.databases}">Databases</a>
+        <a href="/schemas" class="block" th:text="#{console.schemas}">Schemas</a>
+        <a href="/users" class="block" th:text="#{console.users}">Users</a>
+    </aside>
+    <div class="p-4 flex-grow">
+        <nav class="text-sm text-gray-600 mb-4">
+            <a href="/" th:text="#{console.menu.home}">Home</a> / <a href="/console" th:text="#{console.menu.console}">Console</a> / <span th:text="#{databases.title}">Databases</span>
+        </nav>
+        <h2 class="font-semibold mb-2" th:text="#{databases.title}">Databases</h2>
+        <ul class="bg-white shadow rounded p-2">
+            <li th:each="db : ${databases}" th:text="${db}" class="border-b last:border-0 py-1"></li>
+        </ul>
+    </div>
 </main>
-<footer class="bg-gray-200 text-center p-4" th:text="#{footer.copy}">
-    © 2024 My Admin Console
+<footer class="bg-gray-200 text-center p-4">
+    <div th:text="${dbVersion}"></div>
+    <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>
 </body>
 </html>

--- a/src/main/resources/templates/schemas.html
+++ b/src/main/resources/templates/schemas.html
@@ -8,22 +8,28 @@
 <body class="bg-gray-100 min-h-screen flex flex-col">
 <header class="bg-gray-800 text-white p-4 flex justify-between items-center">
     <h1 class="text-xl font-bold" th:text="#{header.title}">Admin Console</h1>
-    <div>
-        <a href="/settings" class="underline mr-4" th:text="#{settings.title}">Settings</a>
-        <span class="text-sm" th:text="${dbVersion}"></span>
-    </div>
+    <a href="/settings" class="underline" th:text="#{settings.title}">Settings</a>
 </header>
-<main class="p-4 flex-grow">
-    <nav class="text-sm text-gray-600 mb-4">
-        <a href="/" th:text="#{console.menu.home}">Home</a> / <a href="/console" th:text="#{console.menu.console}">Console</a> / <span th:text="#{schemas.title}">Schemas</span>
-    </nav>
-    <h2 class="font-semibold mb-2" th:text="#{schemas.title}">Schemas</h2>
-    <ul class="bg-white shadow rounded p-2">
-        <li th:each="schema : ${schemas}" th:text="${schema}" class="border-b last:border-0 py-1"></li>
-    </ul>
+<main class="flex flex-grow">
+    <aside class="w-64 bg-gray-100 p-4 space-y-2">
+        <a href="/console" class="block" th:text="#{console.menu.console}">Console</a>
+        <a href="/databases" class="block" th:text="#{console.databases}">Databases</a>
+        <a href="/schemas" class="block" th:text="#{console.schemas}">Schemas</a>
+        <a href="/users" class="block" th:text="#{console.users}">Users</a>
+    </aside>
+    <div class="p-4 flex-grow">
+        <nav class="text-sm text-gray-600 mb-4">
+            <a href="/" th:text="#{console.menu.home}">Home</a> / <a href="/console" th:text="#{console.menu.console}">Console</a> / <span th:text="#{schemas.title}">Schemas</span>
+        </nav>
+        <h2 class="font-semibold mb-2" th:text="#{schemas.title}">Schemas</h2>
+        <ul class="bg-white shadow rounded p-2">
+            <li th:each="schema : ${schemas}" th:text="${schema}" class="border-b last:border-0 py-1"></li>
+        </ul>
+    </div>
 </main>
-<footer class="bg-gray-200 text-center p-4" th:text="#{footer.copy}">
-    © 2024 My Admin Console
+<footer class="bg-gray-200 text-center p-4">
+    <div th:text="${dbVersion}"></div>
+    <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>
 </body>
 </html>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -8,23 +8,29 @@
 <body class="bg-gray-100 min-h-screen flex flex-col">
 <header class="bg-gray-800 text-white p-4 flex justify-between items-center">
     <h1 class="text-xl font-bold" th:text="#{header.title}">Admin Console</h1>
-    <div>
-        <a href="/settings" class="underline mr-4" th:text="#{settings.title}">Settings</a>
-    </div>
+    <a href="/settings" class="underline" th:text="#{settings.title}">Settings</a>
 </header>
-<main class="p-4 flex-grow">
-    <nav class="text-sm text-gray-600 mb-4">
-        <a href="/" th:text="#{console.menu.home}">Home</a> / <span th:text="#{settings.title}">Settings</span>
-    </nav>
-    <h2 class="font-semibold mb-2" th:text="#{settings.language}">Language</h2>
-    <form method="get" action="/settings" class="space-x-4">
-        <select name="lang" class="border rounded p-1">
-            <option value="en" th:text="#{settings.english}">English</option>
-            <option value="ja" th:text="#{settings.japanese}">Japanese</option>
-        </select>
-        <button type="submit" class="bg-blue-500 text-white px-4 py-1 rounded">OK</button>
-    </form>
-    <p class="mt-2" th:text="#{settings.currentLanguage} + ' ' + ${currentLocale}">Current Language: en</p>
+<main class="flex flex-grow">
+    <aside class="w-64 bg-gray-100 p-4 space-y-2">
+        <a href="/console" class="block" th:text="#{console.menu.console}">Console</a>
+        <a href="/databases" class="block" th:text="#{console.databases}">Databases</a>
+        <a href="/schemas" class="block" th:text="#{console.schemas}">Schemas</a>
+        <a href="/users" class="block" th:text="#{console.users}">Users</a>
+    </aside>
+    <div class="p-4 flex-grow">
+        <nav class="text-sm text-gray-600 mb-4">
+            <a href="/" th:text="#{console.menu.home}">Home</a> / <span th:text="#{settings.title}">Settings</span>
+        </nav>
+        <h2 class="font-semibold mb-2" th:text="#{settings.language}">Language</h2>
+        <form method="get" action="/settings" class="space-x-4">
+            <select name="lang" class="border rounded p-1">
+                <option value="en" th:text="#{settings.english}">English</option>
+                <option value="ja" th:text="#{settings.japanese}">Japanese</option>
+            </select>
+            <button type="submit" class="bg-blue-500 text-white px-4 py-1 rounded">OK</button>
+        </form>
+        <p class="mt-2" th:text="#{settings.currentLanguage} + ' ' + ${currentLocale}">Current Language: en</p>
+    </div>
 </main>
 <footer class="bg-gray-200 text-center p-4" th:text="#{footer.copy}">
     © 2024 My Admin Console

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -8,22 +8,28 @@
 <body class="bg-gray-100 min-h-screen flex flex-col">
 <header class="bg-gray-800 text-white p-4 flex justify-between items-center">
     <h1 class="text-xl font-bold" th:text="#{header.title}">Admin Console</h1>
-    <div>
-        <a href="/settings" class="underline mr-4" th:text="#{settings.title}">Settings</a>
-        <span class="text-sm" th:text="${dbVersion}"></span>
-    </div>
+    <a href="/settings" class="underline" th:text="#{settings.title}">Settings</a>
 </header>
-<main class="p-4 flex-grow">
-    <nav class="text-sm text-gray-600 mb-4">
-        <a href="/" th:text="#{console.menu.home}">Home</a> / <a href="/console" th:text="#{console.menu.console}">Console</a> / <span th:text="#{users.title}">Users</span>
-    </nav>
-    <h2 class="font-semibold mb-2" th:text="#{users.title}">Users</h2>
-    <ul class="bg-white shadow rounded p-2">
-        <li th:each="user : ${users}" th:text="${user}" class="border-b last:border-0 py-1"></li>
-    </ul>
+<main class="flex flex-grow">
+    <aside class="w-64 bg-gray-100 p-4 space-y-2">
+        <a href="/console" class="block" th:text="#{console.menu.console}">Console</a>
+        <a href="/databases" class="block" th:text="#{console.databases}">Databases</a>
+        <a href="/schemas" class="block" th:text="#{console.schemas}">Schemas</a>
+        <a href="/users" class="block" th:text="#{console.users}">Users</a>
+    </aside>
+    <div class="p-4 flex-grow">
+        <nav class="text-sm text-gray-600 mb-4">
+            <a href="/" th:text="#{console.menu.home}">Home</a> / <a href="/console" th:text="#{console.menu.console}">Console</a> / <span th:text="#{users.title}">Users</span>
+        </nav>
+        <h2 class="font-semibold mb-2" th:text="#{users.title}">Users</h2>
+        <ul class="bg-white shadow rounded p-2">
+            <li th:each="user : ${users}" th:text="${user}" class="border-b last:border-0 py-1"></li>
+        </ul>
+    </div>
 </main>
-<footer class="bg-gray-200 text-center p-4" th:text="#{footer.copy}">
-    © 2024 My Admin Console
+<footer class="bg-gray-200 text-center p-4">
+    <div th:text="${dbVersion}"></div>
+    <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- persist DB connection details in cookies
- move DB version display into page footers
- switch admin console screens to two-pane layout

## Testing
- `gradle test` *(fails: Task 'test' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857df1ac4a8832eab370b6d47066d2d