### PR TITLE
Add connection type indicator and query logs

### DIFF
--- a/src/main/java/com/example/demo/HomeController.java
+++ b/src/main/java/com/example/demo/HomeController.java
@@ -1,13 +1,17 @@
 package com.example.demo;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.List;
 
 @Controller
 public class HomeController {
+    private static final Logger logger = LoggerFactory.getLogger(HomeController.class);
     private final VersionMapper versionMapper;
     private final DatabaseInfoMapper databaseInfoMapper;
 
@@ -17,32 +21,58 @@ public class HomeController {
     }
 
     @GetMapping("/console")
-    public String console(Model model) {
-        model.addAttribute("dbVersion", versionMapper.selectVersion());
+    public String console(Model model,
+                          @CookieValue(value = "dbSsl", defaultValue = "false") boolean ssl) {
+        logger.info("Query: SELECT version()");
+        String version = versionMapper.selectVersion();
+        logger.info("Result: {}", version);
+        model.addAttribute("dbVersion", version);
+        model.addAttribute("dbConnectionType", ssl ? "connection.ssl" : "connection.nonssl");
         return "console";
     }
 
     @GetMapping("/databases")
-    public String databases(Model model) {
+    public String databases(Model model,
+                            @CookieValue(value = "dbSsl", defaultValue = "false") boolean ssl) {
+        logger.info("Query: SELECT datname FROM pg_database");
         List<String> databases = databaseInfoMapper.selectDatabases();
-        model.addAttribute("dbVersion", versionMapper.selectVersion());
+        logger.info("Result: {}", databases);
+        logger.info("Query: SELECT version()");
+        String version = versionMapper.selectVersion();
+        logger.info("Result: {}", version);
+        model.addAttribute("dbVersion", version);
         model.addAttribute("databases", databases);
+        model.addAttribute("dbConnectionType", ssl ? "connection.ssl" : "connection.nonssl");
         return "databases";
     }
 
     @GetMapping("/schemas")
-    public String schemas(Model model) {
+    public String schemas(Model model,
+                          @CookieValue(value = "dbSsl", defaultValue = "false") boolean ssl) {
+        logger.info("Query: SELECT schema_name FROM information_schema.schemata");
         List<String> schemas = databaseInfoMapper.selectSchemas();
-        model.addAttribute("dbVersion", versionMapper.selectVersion());
+        logger.info("Result: {}", schemas);
+        logger.info("Query: SELECT version()");
+        String version = versionMapper.selectVersion();
+        logger.info("Result: {}", version);
+        model.addAttribute("dbVersion", version);
         model.addAttribute("schemas", schemas);
+        model.addAttribute("dbConnectionType", ssl ? "connection.ssl" : "connection.nonssl");
         return "schemas";
     }
 
     @GetMapping("/users")
-    public String users(Model model) {
+    public String users(Model model,
+                        @CookieValue(value = "dbSsl", defaultValue = "false") boolean ssl) {
+        logger.info("Query: SELECT usename FROM pg_user");
         List<String> users = databaseInfoMapper.selectUsers();
-        model.addAttribute("dbVersion", versionMapper.selectVersion());
+        logger.info("Result: {}", users);
+        logger.info("Query: SELECT version()");
+        String version = versionMapper.selectVersion();
+        logger.info("Result: {}", version);
+        model.addAttribute("dbVersion", version);
         model.addAttribute("users", users);
+        model.addAttribute("dbConnectionType", ssl ? "connection.ssl" : "connection.nonssl");
         return "users";
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -23,3 +23,5 @@ settings.language=Language
 settings.english=English
 settings.japanese=Japanese
 settings.currentLanguage=Current Language:
+connection.ssl=SSL Connection
+connection.nonssl=Non-SSL Connection

--- a/src/main/resources/messages_ja.properties
+++ b/src/main/resources/messages_ja.properties
@@ -23,3 +23,5 @@ settings.language=\u8a00\u8a9e
 settings.english=\u82f1\u8a9e
 settings.japanese=\u65e5\u672c\u8a9e
 settings.currentLanguage=\u73fe\u5728\u306e\u8a00\u8a9e:
+connection.ssl=SSL\u63a5\u7d9a
+connection.nonssl=\u975eSSL\u63a5\u7d9a

--- a/src/main/resources/templates/console.html
+++ b/src/main/resources/templates/console.html
@@ -29,6 +29,7 @@
     </div>
 </main>
 <footer class="bg-gray-200 text-center p-4">
+    <div th:text="#{${dbConnectionType}}"></div>
     <div th:text="${dbVersion}"></div>
     <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>

--- a/src/main/resources/templates/databases.html
+++ b/src/main/resources/templates/databases.html
@@ -28,6 +28,7 @@
     </div>
 </main>
 <footer class="bg-gray-200 text-center p-4">
+    <div th:text="#{${dbConnectionType}}"></div>
     <div th:text="${dbVersion}"></div>
     <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>

--- a/src/main/resources/templates/schemas.html
+++ b/src/main/resources/templates/schemas.html
@@ -28,6 +28,7 @@
     </div>
 </main>
 <footer class="bg-gray-200 text-center p-4">
+    <div th:text="#{${dbConnectionType}}"></div>
     <div th:text="${dbVersion}"></div>
     <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -28,6 +28,7 @@
     </div>
 </main>
 <footer class="bg-gray-200 text-center p-4">
+    <div th:text="#{${dbConnectionType}}"></div>
     <div th:text="${dbVersion}"></div>
     <div th:text="#{footer.copy}">© 2024 My Admin Console</div>
 </footer>


### PR DESCRIPTION
## Summary
- show connection type using i18n messages
- log queries and results in `HomeController`
- display connection type in footer on console pages

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_6857e4d7f36c832ea37ab1b5e67caabd